### PR TITLE
ACE-24 Fixed pinning time issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN npm install
 # Set the timezone
 RUN apk add --update tzdata
 ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Clean APK cache
 RUN rm -rf /var/cache/apk/*

--- a/startApp.sh
+++ b/startApp.sh
@@ -1,2 +1,0 @@
-docker-compose build
-docker-compose up


### PR DESCRIPTION
Found solution here:  

https://serverfault.com/questions/683605/docker-container-time-timezone-will-not-reflect-changes

* Removed startApp.sh